### PR TITLE
Add PID controller simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # GPTtest
+
+This repository contains a sample PID controller simulation.
+
+Run the script:
+
+```bash
+python pid_simulation.py
+```
+
+It will display and save a plot (`pid_response.png`) of the controller's response.

--- a/pid_simulation.py
+++ b/pid_simulation.py
@@ -1,0 +1,37 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+# Simple PID controller simulation
+# Setpoint is 1.0, plant is a first-order system
+
+def simulate_pid(kp, ki, kd, dt, steps):
+    setpoint = 1.0
+    x = 0.0
+    integral = 0.0
+    prev_error = 0.0
+    history = []
+
+    for _ in range(steps):
+        error = setpoint - x
+        integral += error * dt
+        derivative = (error - prev_error) / dt
+        u = kp * error + ki * integral + kd * derivative
+        x += u * dt  # simple plant: dx/dt = u
+        history.append(x)
+        prev_error = error
+    return history
+
+if __name__ == "__main__":
+    dt = 0.01
+    steps = 1000
+    response = simulate_pid(kp=2.0, ki=1.0, kd=0.1, dt=dt, steps=steps)
+    time = np.arange(steps) * dt
+    plt.plot(time, response, label="Output")
+    plt.axhline(1.0, color="r", linestyle="--", label="Setpoint")
+    plt.xlabel("Time [s]")
+    plt.ylabel("Output")
+    plt.legend()
+    plt.title("PID Controller Response")
+    plt.tight_layout()
+    plt.savefig("pid_response.png")
+    plt.show()


### PR DESCRIPTION
## Summary
- add `pid_simulation.py` showing a PID controller example
- document how to run the simulation in the README

## Testing
- `python pid_simulation.py`

------
https://chatgpt.com/codex/tasks/task_e_684004a7fae48330a82f0f35a714591a